### PR TITLE
Fix Time Zone Bug, Tests and Typos

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -156,7 +156,7 @@ function calculate(latitude, longitude, isSunrise, zenith, date) {
 }
 
 /**
- * Calculate Sunrise time for given longitude, latidue, zenith and date
+ * Calculate Sunrise time for given longitude, latitude, zenith and date
  * 
  * @param {Number} latitude
  * @param {Number} longitude
@@ -168,7 +168,7 @@ export function getSunrise(latitude, longitude, date = new Date()) {
 };
 
 /**
- * Calculate Sunset time for given longitude, latidue, zenith and date
+ * Calculate Sunset time for given longitude, latitude, zenith and date
  * 
  * @param {Number} latitude
  * @param {Number} longitude

--- a/src/index.js
+++ b/src/index.js
@@ -149,7 +149,7 @@ function calculate(latitude, longitude, isSunrise, zenith, date) {
   const localHour = localHourAngle / DEGREES_PER_HOUR;
   const localMeanTime = localHour + rightAscension - (0.06571 * approxTimeOfEventInDays) - 6.622;
   const time = mod(localMeanTime - (longitude / DEGREES_PER_HOUR), 24);
-  const utcMidnight = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+  const utcMidnight = Date.UTC(date.getFullYear(), date.getMonth(), date.getDate());
 
   // Created date will be set to local (system) time zone.
   return new Date(utcMidnight + (time * MSEC_IN_HOUR));

--- a/src/index.js
+++ b/src/index.js
@@ -149,9 +149,10 @@ function calculate(latitude, longitude, isSunrise, zenith, date) {
   const localHour = localHourAngle / DEGREES_PER_HOUR;
   const localMeanTime = localHour + rightAscension - (0.06571 * approxTimeOfEventInDays) - 6.622;
   const time = mod(localMeanTime - (longitude / DEGREES_PER_HOUR), 24);
-  const midnight = new Date(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate(), 0);
+  const utcMidnight = Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
 
-  return new Date(midnight.getTime() + (time * MSEC_IN_HOUR));
+  // Created date will be set to local (system) time zone.
+  return new Date(utcMidnight + (time * MSEC_IN_HOUR));
 }
 
 /**

--- a/src/index.js
+++ b/src/index.js
@@ -159,7 +159,7 @@ function calculate(latitude, longitude, isSunrise, zenith, date) {
  * Calculate Sunrise time for given longitude, latidue, zenith and date
  * 
  * @param {Number} latitude
- * @param {Number} latitude
+ * @param {Number} longitude
  * @param {Date} [date]
  * @returns {Date}
  */
@@ -171,7 +171,7 @@ export function getSunrise(latitude, longitude, date = new Date()) {
  * Calculate Sunset time for given longitude, latidue, zenith and date
  * 
  * @param {Number} latitude
- * @param {Number} latitude
+ * @param {Number} longitude
  * @param {Date} [date]
  * @returns {Date}
  */

--- a/tests/index.test.js
+++ b/tests/index.test.js
@@ -4,13 +4,22 @@ describe('SunriseSunsetJS library', () => {
   it('should have getSunrise, getSunset exported methods', () => {
     expect(typeof getSunrise).toBe('function');
     expect(typeof getSunset).toBe('function');
-  })
+  });
 
-  it('should return correct sunrise time', () => {
-    expect(getSunrise(51.1788, -1.8262, new Date("2000-06-21")).getTime()).toEqual(961548706140)
-  })
+  it('should return correct sunrise time for GMT', () => {
+    expect(getSunrise(51.1788, -1.8262, new Date("2000-01-21 12:00:00 GMT")))
+        .toEqual(new Date("Fri, 21 Jan 2000 07:59:37.362 GMT"))
+  });
 
-  it('should return correct sunset time', () => {
-    expect(getSunset(51.1788, -1.8262, new Date("2000-06-21")).getTime()).toEqual(961608396293)
-  })
+  it('should return correct sunset time for GMT', () => {
+    expect(getSunset(51.1788, -1.8262, new Date("2000-01-21 12:00:00 GMT")))
+        .toEqual(new Date("Fri, 21 Jan 2000 16:38:21.883 GMT"))
+  });
+
+  it('should return correct sunrise time for CEST', () => {
+      expect(getSunrise(46.0207, 7.7491, new Date('Sat Apr 13 2019 21:51:00 GMT+0200 (Central European Summer Time)'))
+          ).toEqual(new Date('Sat Apr 13 2019 06:47:17.878 GMT+0200 (Central European Summer Time)'))
+  });
+
 })
+


### PR DESCRIPTION
Content:

1. Previously, the result of getSunset and getSunrise would be a Date object in the local (system) time zone, but the time represented would be the UTC time (issue #2 and #4)
2. Fixed two typos, similar to #3 
3. Made sure tests could run anywhere and any system. Previously, they would only pass on systems with the correct time zone.
4. Previously, the date of the output could be different from the input date, due to time zone conversion. This is now fixed.