### PR TITLE
Fix typescript definition

### DIFF
--- a/dist/index.d.ts
+++ b/dist/index.d.ts
@@ -12,5 +12,5 @@ declare module 'sunrise-sunset-js' {
     date?: Date,
   ): Date;
 
-  export = { getSunrise, getSunset };
+  export { getSunrise, getSunset };
 }


### PR DESCRIPTION
I'm getting typescript error (3.6.4) - "The expression of an export assignment must be an identifier or qualified name in an ambient context." Without equal it works.