### PR TITLE
Keep solar noon and twilight during polar day and night

### DIFF
--- a/src/calculations/rts.ts
+++ b/src/calculations/rts.ts
@@ -238,21 +238,15 @@ export function calculateEotAndSunRiseTransitSet(
   // Calculate hour angle at rise/set
   const h0 = sunHourAngleAtRiseSet(spa.latitude, delta[JDSign.JD_ZERO], h0Prime);
 
-  // Handle polar day/night
-  if (h0 === INVALID_VALUE) {
-    return {
-      sunrise: INVALID_VALUE,
-      suntransit: INVALID_VALUE,
-      sunset: INVALID_VALUE,
-      srha: INVALID_VALUE,
-      ssha: INVALID_VALUE,
-      sta: INVALID_VALUE,
-      eot,
-    };
-  }
+  const polar = h0 === INVALID_VALUE;
 
-  // Calculate approximate rise/set times
-  approxSunRiseAndSet(mRts, h0);
+  if (polar) {
+    // No rise/set to derive it from, so normalise the transit here
+    mRts[SunState.SUN_TRANSIT] = limitZero2one(mRts[SunState.SUN_TRANSIT]);
+  } else {
+    // Calculate approximate rise/set times
+    approxSunRiseAndSet(mRts, h0);
+  }
 
   // Refine calculations using interpolation
   const nuRts: number[] = [];
@@ -261,7 +255,10 @@ export function calculateEotAndSunRiseTransitSet(
   const deltaPrime: number[] = [];
   const hRts: number[] = [];
 
-  for (let i = 0; i < SunState.SUN_COUNT; i++) {
+  // Only the transit slot is meaningful during polar day/night
+  const rtsCount = polar ? SunState.SUN_TRANSIT + 1 : SunState.SUN_COUNT;
+
+  for (let i = 0; i < rtsCount; i++) {
     nuRts[i] = nu + 360.985647 * mRts[i];
     const n = mRts[i] + spa.deltaT / 86400.0;
     alphaPrime[i] = rtsAlphaDeltaPrime(alpha, n);
@@ -271,14 +268,28 @@ export function calculateEotAndSunRiseTransitSet(
   }
 
   // Calculate final times
-  const srha = hPrime[SunState.SUN_RISE];
-  const ssha = hPrime[SunState.SUN_SET];
   const sta = hRts[SunState.SUN_TRANSIT];
 
   const suntransit = dayfracToLocalHr(
     mRts[SunState.SUN_TRANSIT] - hPrime[SunState.SUN_TRANSIT] / 360.0,
     spa.timezone
   );
+
+  if (polar) {
+    // The sun crosses the meridian every day, even when it never crosses the horizon
+    return {
+      sunrise: INVALID_VALUE,
+      suntransit,
+      sunset: INVALID_VALUE,
+      srha: INVALID_VALUE,
+      ssha: INVALID_VALUE,
+      sta,
+      eot,
+    };
+  }
+
+  const srha = hPrime[SunState.SUN_RISE];
+  const ssha = hPrime[SunState.SUN_SET];
 
   const sunrise = dayfracToLocalHr(
     sunRiseAndSet(mRts, hRts, deltaPrime, spa.latitude, hPrime, h0Prime, SunState.SUN_RISE),

--- a/src/index.ts
+++ b/src/index.ts
@@ -16,6 +16,7 @@ import {
   ZENITH_ASTRONOMICAL_TWILIGHT,
   ZENITH_GOLDEN_HOUR,
   ZENITH_BLUE_HOUR,
+  INVALID_VALUE,
 } from './constants';
 import { fractionalHourToDate } from './utils/time';
 import {
@@ -249,7 +250,8 @@ export function getTwilight(
 
   // Convert fractional hours to Date objects
   const toDate = (hours: number | null): Date | null => {
-    if (hours === null || !isFinite(hours)) {
+    // INVALID_VALUE is finite, so isFinite alone would let the sentinel through
+    if (hours === null || hours === INVALID_VALUE || !isFinite(hours)) {
       return null;
     }
     return fractionalHourToDate(
@@ -372,7 +374,8 @@ export function getSunTimes(
     );
 
     const twilightToDate = (hours: number | null): Date | null => {
-      if (hours === null || !isFinite(hours)) {
+      // INVALID_VALUE is finite, so isFinite alone would let the sentinel through
+      if (hours === null || hours === INVALID_VALUE || !isFinite(hours)) {
         return null;
       }
       return fractionalHourToDate(

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -157,3 +157,158 @@ describe('SunriseSunsetJS library', () => {
     }
   });
 });
+
+/**
+ * Reference times below were cross-checked against two independent implementations that
+ * agree with each other to about a second: pvlib's NREL SPA and skyfield/JPL DE421.
+ * `null` means the sun never reaches that angle on that day, so the event does not exist.
+ * Every case passes `timezone: 0` so the expected values do not depend on the runner's TZ.
+ */
+const UTC = { timezone: 0 };
+
+const POLAR_CASES = [
+  {
+    name: 'Tromsø during polar night',
+    lat: 69.6496, lon: 18.9560, date: '2026-12-21T12:00:00Z',
+    solarNoon: '2026-12-21T10:42:12.4Z', peakElevation: -3.089,
+    civil: ['2026-12-21T08:31:15.5Z', '2026-12-21T12:53:09.1Z'],
+    nautical: ['2026-12-21T06:46:42.9Z', '2026-12-21T14:37:41.7Z'],
+    astronomical: ['2026-12-21T05:28:19.7Z', '2026-12-21T15:56:04.8Z'],
+  },
+  {
+    name: 'Utqiaġvik during polar night',
+    lat: 71.2906, lon: -156.7886, date: '2026-12-21T12:00:00Z',
+    solarNoon: '2026-12-21T22:25:26.0Z', peakElevation: -4.731,
+    civil: ['2026-12-21T20:56:06.1Z', '2026-12-21T23:54:46.0Z'],
+    nautical: ['2026-12-21T18:45:24.4Z', '2026-12-22T02:05:27.6Z'],
+    astronomical: ['2026-12-21T17:18:33.8Z', '2026-12-22T03:32:18.3Z'],
+  },
+  {
+    name: 'Longyearbyen during polar night',
+    lat: 78.2232, lon: 15.6267, date: '2026-12-21T12:00:00Z',
+    solarNoon: '2026-12-21T10:55:31.4Z', peakElevation: -11.662,
+    civil: null,
+    nautical: ['2026-12-21T09:58:28.5Z', '2026-12-21T11:52:34.3Z'],
+    astronomical: ['2026-12-21T06:37:06.9Z', '2026-12-21T15:13:55.6Z'],
+  },
+  {
+    name: 'Longyearbyen under the midnight sun',
+    lat: 78.2232, lon: 15.6267, date: '2026-06-21T12:00:00Z',
+    solarNoon: '2026-06-21T10:59:17.9Z', peakElevation: 35.236,
+    civil: null, nautical: null, astronomical: null,
+  },
+  {
+    name: 'McMurdo under the midnight sun',
+    lat: -77.8419, lon: 166.6863, date: '2026-12-21T12:00:00Z',
+    solarNoon: '2026-12-21T00:51:06.3Z', peakElevation: 35.614,
+    civil: null, nautical: null, astronomical: null,
+  },
+  {
+    name: 'McMurdo during polar night',
+    lat: -77.8419, lon: 166.6863, date: '2026-06-21T12:00:00Z',
+    solarNoon: '2026-06-21T00:54:57.8Z', peakElevation: -11.282,
+    civil: null,
+    nautical: ['2026-06-20T23:32:49.1Z', '2026-06-21T02:17:06.6Z'],
+    astronomical: ['2026-06-20T20:32:33.1Z', '2026-06-21T05:17:22.4Z'],
+  },
+] as const;
+
+describe('polar day and night', () => {
+  for (const c of POLAR_CASES) {
+    it(`reports solar noon ${c.name}`, () => {
+      const date = new Date(c.date);
+      const noon = getSolarNoon(c.lat, c.lon, date, UTC);
+
+      expect(noon).not.toBeNull();
+      expect(Math.abs(noon!.getTime() - Date.parse(c.solarNoon))).toBeLessThan(3000);
+      // the transit is real: the library's own engine puts the sun at its daily peak there
+      expect(getSolarPosition(c.lat, c.lon, noon!, UTC)!.elevation).toBeCloseTo(c.peakElevation, 2);
+
+      // and the sun genuinely never crosses the horizon, so these must stay null
+      expect(getSunrise(c.lat, c.lon, date, UTC)).toBeNull();
+      expect(getSunset(c.lat, c.lon, date, UTC)).toBeNull();
+    });
+
+    it(`grades twilight per zenith angle ${c.name}`, () => {
+      const date = new Date(c.date);
+      const twilight = getTwilight(c.lat, c.lon, date, UTC);
+      expect(twilight).not.toBeNull();
+
+      const noon = getSolarNoon(c.lat, c.lon, date, UTC)!.getTime();
+      const bands = [
+        [c.civil, twilight!.civilDawn, twilight!.civilDusk],
+        [c.nautical, twilight!.nauticalDawn, twilight!.nauticalDusk],
+        [c.astronomical, twilight!.astronomicalDawn, twilight!.astronomicalDusk],
+      ] as const;
+
+      for (const [expected, dawn, dusk] of bands) {
+        if (expected === null) {
+          expect(dawn).toBeNull();
+          expect(dusk).toBeNull();
+          continue;
+        }
+        expect(dawn).not.toBeNull();
+        expect(dusk).not.toBeNull();
+        expect(Math.abs(dawn!.getTime() - Date.parse(expected[0]))).toBeLessThan(60000);
+        expect(Math.abs(dusk!.getTime() - Date.parse(expected[1]))).toBeLessThan(60000);
+        expect(dawn!.getTime()).toBeLessThan(noon);
+        expect(noon).toBeLessThan(dusk!.getTime());
+      }
+    });
+  }
+
+  it('reports solar noon at every latitude on every day of the year', () => {
+    const latitudes = [-90, -89, -78.2232, -66.5606, -45, 0, 45, 66.5606, 78.2232, 89, 90];
+    const dates = ['2026-01-15', '2026-03-20', '2026-06-21', '2026-09-23', '2026-12-21'];
+
+    for (const lat of latitudes) {
+      for (const day of dates) {
+        const date = new Date(`${day}T12:00:00Z`);
+        const where = `lat ${lat} on ${day}`;
+        expect(getSolarNoon(lat, 15, date, UTC), where).not.toBeNull();
+        expect(getTwilight(lat, 15, date, UTC), where).not.toBeNull();
+        expect(getSunTimes(lat, 15, date, UTC).solarNoon, where).not.toBeNull();
+        expect(getSunTimes(lat, 15, date, UTC).twilight, where).not.toBeNull();
+      }
+    }
+  });
+
+  it('never leaks the polar sentinel into a returned date', () => {
+    const latitudes = [-90, -85, -78.2232, -70, 70, 78.2232, 85, 90];
+    const dates = ['2026-06-21', '2026-12-21'];
+
+    for (const lat of latitudes) {
+      for (const day of dates) {
+        const date = new Date(`${day}T12:00:00Z`);
+        const twilight = getTwilight(lat, 15, date, UTC)!;
+        const times = [
+          twilight.civilDawn, twilight.civilDusk,
+          twilight.nauticalDawn, twilight.nauticalDusk,
+          twilight.astronomicalDawn, twilight.astronomicalDusk,
+          twilight.goldenHour.morning.start, twilight.goldenHour.morning.end,
+          twilight.goldenHour.evening.start, twilight.goldenHour.evening.end,
+          twilight.blueHour.morning.start, twilight.blueHour.morning.end,
+          twilight.blueHour.evening.start, twilight.blueHour.evening.end,
+        ];
+
+        for (const time of times) {
+          if (time === null) continue;
+          expect(Number.isNaN(time.getTime()), `lat ${lat} on ${day}`).toBe(false);
+          const hoursAway = Math.abs(time.getTime() - date.getTime()) / 3600000;
+          expect(hoursAway, `lat ${lat} on ${day}: ${time.toISOString()}`).toBeLessThan(36);
+        }
+      }
+    }
+  });
+
+  it('leaves non-polar results untouched', () => {
+    const date = new Date('2026-12-21T12:00:00Z');
+    const times = getSunTimes(51.5074, -0.1278, date, UTC);
+
+    expect(times.sunrise!.toISOString()).toBe('2026-12-21T08:03:43.968Z');
+    expect(times.solarNoon!.toISOString()).toBe('2026-12-21T11:58:34.713Z');
+    expect(times.sunset!.toISOString()).toBe('2026-12-21T15:53:25.078Z');
+    expect(times.twilight!.civilDawn!.toISOString()).toBe('2026-12-21T07:23:29.608Z');
+    expect(times.twilight!.civilDusk!.toISOString()).toBe('2026-12-21T16:33:39.818Z');
+  });
+});

--- a/tests/temporal.test.ts
+++ b/tests/temporal.test.ts
@@ -4,7 +4,7 @@ import {
   getSunTimes,
   TemporalDateInput,
 } from '../src/temporal';
-import { getSunrise as getDateSunrise } from '../src/index';
+import { getSunrise as getDateSunrise, getSunTimes as getDateSunTimes } from '../src/index';
 
 class MockInstant {
   constructor(readonly epochMilliseconds: number) {}
@@ -118,6 +118,20 @@ describe('Temporal API', () => {
     expect(times.solarNoon).toBeInstanceOf(MockInstant);
     expect(times.twilight!.civilDawn).toBeInstanceOf(MockInstant);
     expect(times.twilight!.goldenHour!.morning.start).toBeInstanceOf(MockInstant);
+  });
+
+  it('returns solar noon and twilight during polar night', () => {
+    const date = new Date('2026-12-21T12:00:00Z');
+    const times = getSunTimes(69.6496, 18.9560, date, { timezone: 0 });
+
+    expect(times.sunrise).toBeNull();
+    expect(times.sunset).toBeNull();
+    expect(times.solarNoon).toBeInstanceOf(MockInstant);
+    expect(times.solarNoon!.epochMilliseconds).toBe(
+      getDateSunTimes(69.6496, 18.9560, date, { timezone: 0 }).solarNoon!.getTime()
+    );
+    expect(times.twilight!.civilDawn).toBeInstanceOf(MockInstant);
+    expect(times.twilight!.civilDusk).toBeInstanceOf(MockInstant);
   });
 
   it('throws when native Temporal is unavailable', () => {


### PR DESCRIPTION
At Tromsø (69.6496, 18.9560) on 2026-12-21 the sun peaks at −3.09° and civil dawn/dusk really do occur, at 08:31 and 12:53 UTC — but `getSolarNoon` returns `null` and `getTwilight` returns `null` for the whole object; same under the midnight sun (Longyearbyen, 2026-06-21). `calculateEotAndSunRiseTransitSet` short-circuits when the *sunrise* hour angle is invalid and throws the meridian transit away with it, and `getSolarNoon`/`getTwilight`/`getSunTimes` all gate on that transit, so this keeps the transit and skips only the rise/set refinement. `getSunrise`/`getSunset` still return `null` above the polar circles, so #17's behaviour is unchanged; what changes is that `calculateCustomZenithTimes` becomes reachable and grades each angle separately — Longyearbyen on 2026-12-21 now reports no civil twilight but real nautical and astronomical times. Restoring the transit also exposed a second bug that has to go in the same change: `INVALID_VALUE` is `-99999`, which is finite, so the `isFinite` guard in the twilight `toDate` helpers let the sentinel through and stamped the golden/blue hour endpoints about eleven years in the past.

Checked against pvlib's NREL SPA and skyfield/JPL DE421, which agree with each other to roughly a second: the restored transits match to ≤0.21 s and the twilight times to ≤11 s. Over a 1344-row lat×lon×date grid every timestamp the library already returned is byte-identical and nothing became `null`, while 462 rows gained a solar noon; `npm test` is green with vitest going 18 → 34 plus the 4 build tests, and reverting just the two source files fails 15 of them.
